### PR TITLE
Dont unfollow specific users

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -119,7 +119,7 @@ class InstaBot:
                  proxy="",
                  user_blacklist={},
                  tag_blacklist=[],
-                 unwanted_username_list=[]
+                 unwanted_username_list=[],
                  user_avoid_rules={}):
 
         self.bot_start = datetime.datetime.now()


### PR DESCRIPTION
## Issue
The bot unfollows Selebgrams which shouldn't be unfollowed

## Solution
Create a parameter holding the user_name (and user_id if known) and avoid unfollowing these

## To be done if merged
example.py and README.md should include instructions on how to define "keepers" with the parameter:
`user_avoid_rules={'9gag': '259220806'}`

## Changes
1. Added dict for holding specific users: user_avoid_rules {username: user_id}
2. New function to populate user_id if its not known: populate_user_norules()
3. Inserted check for users in dict in the function unfollow(), to ensure that they will not be unfollowed
4. Parameters is served in the example.py with: `user_avoid_rules={'9gag': '259220806'}` or `user_avoid_rules={'9gag': ''}`