### PR TITLE
Unlike likes after x time

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -610,6 +610,8 @@ class InstaBot:
                     self.next_iteration["Unlike"] = time.time() + self.add_time(self.like_delay)
                     # Del first media_id
                 del self.media_liked_by_id[0]
+        else:
+            self.next_iteration["Unlike"] = time.time() + self.add_time(self.like_delay)
 
     def new_auto_mod_follow(self):
         if time.time() > self.next_iteration["Follow"] and \

--- a/src/instabot.py
+++ b/src/instabot.py
@@ -462,7 +462,7 @@ class InstaBot:
                     log_string = "Slow Down - Pausing for 5 minutes so we don't get banned!"
                     self.write_log(log_string)
                     time.sleep(300)
-                    unlike = self.s.post(unlike)
+                    unlike = self.s.post(url_unlike)
                     if unlike.status_code == 200:
                         self.unlike_counter += 1
                         log_string = "Unlike: %s #%i of %i." % (media_id, self.unlike_counter, self.like_counter)

--- a/src/instabot.py
+++ b/src/instabot.py
@@ -427,7 +427,7 @@ class InstaBot:
                 self.like_status = 1
             except:
                 self.write_log("Except on like!")
-                like_status = 0
+                self.like_status = 0
                 like = 0
             return like
 


### PR DESCRIPTION
## Issue
Your profile history is getting spammed up by strange likes.

## Solution
Start unliking after a specified time interval.
When you have liked more than 1 post (2 likes) AND your delay time (unlike_like_after) has finished, you'll start unliking a post in the same interval, as you'll like them.

## How to
Specify the parameter unlike_like_after in seconds in example.py
`unlike_like_after=3600` = Waits approximate 3600 seconds
`unlike_like_after=0` = Disabled

## Changes
Unlike function is modified: `unlike(self, media_id)`
New iteration function created: `new_auto_mod_unlike(self)`
New unlike cleanup function created: `unlike_on_cleanup(self, media_id)`
self.like_status to control that a like has worked
Minor changes

## Issues/todo
Instead of dealy timer, just use a simple "unlike after x likes" with `self.like_counter`
