### PR TITLE
Updated .gitignore for IntelliJ related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# IDEs
+.idea/
+*.iml


### PR DESCRIPTION
While working on #519 with IntelliJ , I noticed that ```.gitignore``` file did not include any mention to the offending files that IntelliJ generates:
[![https://gyazo.com/e3fabc1617693fd2ce18d8b8eda7bbe4](https://i.gyazo.com/e3fabc1617693fd2ce18d8b8eda7bbe4.png)](https://gyazo.com/e3fabc1617693fd2ce18d8b8eda7bbe4)