### PR TITLE
Fix bug

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -315,7 +315,6 @@ class InstaBot:
         # Logout
         if (self.login_status):
             self.logout()
-        exit(0)
 
     def get_media_id_by_tag(self, tag):
         """ Get media ID set, by your hashtag """


### PR DESCRIPTION
exit(0)  causes atexit._run_exitfuncs Error and forces to exit the program by raising SystemExit.