### PR TITLE
A better 403 error fix.

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -20,6 +20,7 @@ from .sql_updates import insert_media, insert_username, insert_unfollow_count
 from .sql_updates import get_usernames_first, get_usernames, get_username_random
 from .sql_updates import check_and_insert_user_agent
 from fake_useragent import UserAgent
+import re
 
 class InstaBot:
     """
@@ -55,7 +56,7 @@ class InstaBot:
     url_login = 'https://www.instagram.com/accounts/login/ajax/'
     url_logout = 'https://www.instagram.com/accounts/logout/'
     url_media_detail = 'https://www.instagram.com/p/%s/?__a=1'
-    url_user_detail = 'https://www.instagram.com/%s/?__a=1'
+    url_user_detail = 'https://www.instagram.com/%s/'
     api_user_detail = 'https://i.instagram.com/api/v1/users/%s/info/'
 
     user_agent = "" ""
@@ -843,7 +844,7 @@ class InstaBot:
                 url_tag = self.url_user_detail % (current_user)
                 try:
                     r = self.s.get(url_tag)
-                    all_data = json.loads(r.text)
+                    all_data = json.loads(re.search('{"activity.+show_app', r.text, re.DOTALL).group(0)+'":""}')['entry_data']['ProfilePage'][0]
 
                     user_info = all_data['graphql']['user']
                     i = 0

--- a/src/userinfo.py
+++ b/src/userinfo.py
@@ -3,6 +3,7 @@
 
 import json
 import requests
+import re
 
 class UserInfo:
     '''
@@ -10,7 +11,7 @@ class UserInfo:
     '''
     user_agent = ("Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 "
                   "(KHTML, like Gecko) Chrome/48.0.2564.103 Safari/537.36")
-    url_user_info = "https://www.instagram.com/%s/?__a=1"
+    url_user_info = "https://www.instagram.com/%s/"
     url_list = {
         "ink361": {
             "main": "http://ink361.com/",
@@ -38,8 +39,8 @@ class UserInfo:
     def get_user_id_by_login(self, user_name):
         url_info = self.url_user_info % (user_name)
         info = self.s.get(url_info)
-        all_data = json.loads(info.text)
-        id_user = all_data['graphql']['user']['id']
+        json_info = json.loads(re.search('{"activity.+show_app', info.text, re.DOTALL).group(0)+'":""}')
+        id_user = json_info['entry_data']['ProfilePage'][0]['graphql']['user']['id']
         return id_user
 
     def search_user(self, user_id=None, user_name=None):


### PR DESCRIPTION
Most of the information we need is available within a JSON dump on the html page. Using a regular expression, we can isolate that JSON dump.

The other PRs only seem to address the issue of logging in. This one also addresses other exceptions I've seen (e.g. unable to auto unfollow).