### PR TITLE
Feature: unfollow_count handled properly, follow_time parameter used

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -866,7 +866,7 @@ class InstaBot:
                 url_tag = self.url_user_detail % (current_user)
                 try:
                     r = self.s.get(url_tag)
-                    all_data = json.loads(re.search('{"activity.+show_app', r.text, re.DOTALL).group(0)+'":""}')['entry_data']['ProfilePage'][0]
+                    all_data = json.loads(re.search('{"activity_.+(}(?=.*</script>))', r.text).group(0))['entry_data']['ProfilePage'][0]
 
                     user_info = all_data['graphql']['user']
                     i = 0

--- a/src/instabot.py
+++ b/src/instabot.py
@@ -957,6 +957,9 @@ class InstaBot:
                 self.unfollow(current_id)
                 # don't insert unfollow count as it is done now inside unfollow()
                 #insert_unfollow_count(self, user_id=current_id)
+            elif self.is_following is not True:
+                # we are not following this account, hence we unfollowed it, let's keep track
+                insert_unfollow_count(self, user_id=current_id)
 
     def get_media_id_recent_feed(self):
         if self.login_status:

--- a/src/new_unfollow.py
+++ b/src/new_unfollow.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from .sql_updates import insert_unfollow_count
 
 def new_unfollow(self, user_id, user_name):
     """ Send http request to unfollow """
@@ -12,6 +13,7 @@ def new_unfollow(self, user_id, user_name):
             log_string = "Unfollow: %s #%i." % (user_name,
                                                 self.unfollow_counter)
             self.write_log(log_string)
+            insert_unfollow_count(self, user_id=user_id)
         return unfollow
     except:
         self.write_log("Exept on unfollow!")

--- a/src/sql_updates.py
+++ b/src/sql_updates.py
@@ -23,7 +23,7 @@ def check_and_update(self):
     if not table_column_status:
         qry = """
             CREATE TABLE "usernames_new" ( `username_id` varchar ( 300 ), `username` TEXT  );
-            INSERT INTO "usernames_new" (username_id) Select username from usernames;
+            INSERT INTO "usernames_new" (username) Select username from usernames;
             DROP TABLE "usernames";
             ALTER TABLE "usernames_new" RENAME TO "usernames";
               """
@@ -45,7 +45,7 @@ def check_and_update(self):
     #table_column_status = [o for o in table_info if o[1] == "last_followed_time"]
     #if not table_column_status:
     #    self.follows_db_c.execute("ALTER TABLE usernames ADD COLUMN last_followed_time TEXT")
-    
+
 
 def check_already_liked(self, media_id):
     """ controls if media already liked before """
@@ -58,6 +58,13 @@ def check_already_followed(self, user_id):
     """ controls if user already followed before """
     if self.follows_db_c.execute("SELECT EXISTS(SELECT 1 FROM usernames WHERE username_id='"+
                                  user_id + "' LIMIT 1)").fetchone()[0] > 0:
+        return 1
+    return 0
+
+def check_already_unfollowed(self, user_id):
+    """ controls if user was already unfollowed before """
+    if self.follows_db_c.execute("SELECT EXISTS(SELECT 1 FROM usernames WHERE username_id='"+
+                                 user_id + "' AND unfollow_count > 0 LIMIT 1)").fetchone()[0] > 0:
         return 1
     return 0
 

--- a/src/sql_updates.py
+++ b/src/sql_updates.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sqlite3
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 
 def check_and_update(self):
     """ At the Program start, i does look for the sql updates """
@@ -114,6 +114,18 @@ def get_usernames(self):
 def get_username_random(self):
     """ Gets random username """
     username = self.follows_db_c.execute("SELECT * FROM usernames WHERE unfollow_count=0 ORDER BY RANDOM() LIMIT 1").fetchone()
+    if username:
+        return username
+    else:
+        return False
+
+def get_username_to_unfollow_random(self):
+    """ Gets random username that is older than follow_time and has zero unfollow_count """
+    now_time = datetime.now()
+    cut_off_time = now_time - timedelta(seconds=self.follow_time)
+    username = self.follows_db_c.execute("SELECT * FROM usernames WHERE \
+    DATETIME(last_followed_time) < DATETIME('"+str(cut_off_time)+"') \
+    AND unfollow_count=0 ORDER BY RANDOM() LIMIT 1").fetchone()
     if username:
         return username
     else:

--- a/src/userinfo.py
+++ b/src/userinfo.py
@@ -39,7 +39,7 @@ class UserInfo:
     def get_user_id_by_login(self, user_name):
         url_info = self.url_user_info % (user_name)
         info = self.s.get(url_info)
-        json_info = json.loads(re.search('{"activity.+show_app', info.text, re.DOTALL).group(0)+'":""}')
+        json_info = json.loads(re.search('{"activity_.+(}(?=.*</script>))', info.text).group(0))
         id_user = json_info['entry_data']['ProfilePage'][0]['graphql']['user']['id']
         return id_user
 

--- a/src/userinfo.py
+++ b/src/userinfo.py
@@ -39,7 +39,7 @@ class UserInfo:
     def get_user_id_by_login(self, user_name):
         url_info = self.url_user_info % (user_name)
         info = self.s.get(url_info)
-        json_info = json.loads(re.search('{"activity_.+(}(?=.*</script>))', info.text).group(0))
+        json_info = json.loads(re.search('window._sharedData = (.*?);</script>', info.text, re.DOTALL).group(1))
         id_user = json_info['entry_data']['ProfilePage'][0]['graphql']['user']['id']
         return id_user
 


### PR DESCRIPTION
This update mainly does:
1. Makes sure unfollow_count increases in follows_db when account is unfollowed
2. Does not unfollow users that were already unfollowed on cleanup
3. Minor big fixes (details below)

Based on bug fixes from my Pull Request #1719 

Changes by file: 

a. src/sql_updates.py:
    1. Minor bug fix: on re-creation of usernames table, old username column is copied into new username column (instead of username_id - wrong)
    2. New function defined: check_already_unfollowed - it checks whether there is user_id with unfollow_count > 0 in follows_db

b. src/instabot.py: 
    1. cleanup function: when unfollowing on cleanup - it checks whether the user was already unfollowed and does not unfollow again if it was
    2. cleanup function bugfix: changed "for f in self.bot_follow_list:" into "for i in range(len(self.bot_follow_list)):" because the former combined with "self.bot_follow_list.remove(f)" results in only half of the list being iterated over
    3. unfollow function: now increases unfollow_count when successfully unfollowing user
    4. unfollow_on_cleanup function: now increases unfollow_count when successfully unfollowing user
    5. auto_unfollow function: removed call for insert_unfollow_count function as it is done now from unfollow function

c. src/new_unfollow.py:
    1. new_unfollow function: now increases unfollow_count when successfully unfollowing user