### PR TITLE
bot closes correctly when using it as a systemctl service. added logging from streamhandler

### DIFF
--- a/src/instabot.py
+++ b/src/instabot.py
@@ -1021,6 +1021,18 @@ class InstaBot:
                 self.hdrl.setFormatter(formatter)
                 self.logger.setLevel(level=logging.INFO)
                 self.logger.addHandler(self.hdrl)
+        elif self.log_mod == 2:
+            #Log to Service Log File
+            if self.log_file == 0:
+                #Setup Handle
+                self.log_file = 1
+                formatter = logging.Formatter('%(name)s '
+                                              '- %(message)s')
+                self.logger = logging.getLogger(self.user_login)
+                self.hdrl = logging.StreamHandler()
+                self.hdrl.setFormatter(formatter)
+                self.logger.setLevel(level=logging.INFO)
+                self.logger.addHandler(self.hdrl)
             # Log to log file.
             try:
                 self.logger.info(log_text)


### PR DESCRIPTION
I started using instabot on rasperry pi zero w as a systemctl service. 

But there were two problems.

1. on systemctl stop instabot the bot didn't ends itself and systemctl didn't get the python process to end.
So, i implemented the sigterm signal and end the while loop correctly if sigterm is received.

2. Logging to systemlogfile didn't work correctly when using bot as a service. 
So i implemented an additional logging path. i takes the output from the streamhandler and writes it into syslog.