### PR TITLE
Recent Feed & Follow time fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # InstaBot
 
----
+Instabot is a toolkit written in Python for building Instagram bots using the undocumented private API. 
 
-### Since the bot has received major updates the past few days, very old issues have been closed. If you're still experiencing any problems with the latest version, please feel free to reopen them.
-
-### Please do not clone this repo and publish it as your own. Fork the repo if you wish to publish any changes.
-
----
-
-> Toolkit for building automated Instagram bots without direct access to the Instagram API or passsing through the review process.
+Please do not clone this repo and publish it as your own. Fork the repo if you wish to publish any changes.
 
 [![Donate](https://img.shields.io/badge/PayPal-Donate-brightgreen.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=7BMM6JGE73322&lc=US)
 [![Chat on Telegram](https://img.shields.io/badge/Chat%20on-Telegram-brightgreen.svg)](https://t.me/joinchat/DYKH-0G_8hsDDoN_iE8ZlA)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | follow_time          | int | Seconds to wait before unfollowing                   | 5 * 60 * 60 |
 | follow_time_enabled  | bool| Whether to wait seconds set in follow_time before unfollowing | True |
 | unfollow_per_day     | int | Users to unfollow per day                            | 0    |
-| unfollow_from_recent_feed | bool| If enabled, will populate database with users from recent feed and check them against unfollow conditions. Disable if you only want the bot to unfollow people it has previously followed. | True |
+| unfollow_recent_feed | bool| If enabled, will populate database with users from recent feed and unfollow if they meet the conditions. Disable if you only want the bot to unfollow people it has previously followed. | True |
 | comments_per_day     | int | Comments to post per day                             | 0    |
 | comment_list         | [[str]] | List of word lists for comment generation        | [['this', 'your'], ['photo', 'picture', 'pic', 'shot'], ['is', 'looks', 'is really'], ['great', 'super', 'good'], ['.', '...', '!', '!!']] |
 | tag_list             | [str] | Tags to use for finding posts by hasthag or location(l:locationid from e.g. https://www.instagram.com/explore/locations/212999109/los-angeles-california/)                     | ['cat', 'car', 'dog', 'l:212999109'] |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 | follow_time          | int | Seconds to wait before unfollowing                   | 5 * 60 * 60 |
 | follow_time_enabled  | bool| Whether to wait seconds set in follow_time before unfollowing | True |
 | unfollow_per_day     | int | Users to unfollow per day                            | 0    |
+| unfollow_from_recent_feed | bool| If enabled, will populate database with users from recent feed and check them against unfollow conditions. Disable if you only want the bot to unfollow people it has previously followed. | True |
 | comments_per_day     | int | Comments to post per day                             | 0    |
 | comment_list         | [[str]] | List of word lists for comment generation        | [['this', 'your'], ['photo', 'picture', 'pic', 'shot'], ['is', 'looks', 'is really'], ['great', 'super', 'good'], ['.', '...', '!', '!!']] |
 | tag_list             | [str] | Tags to use for finding posts by hasthag or location(l:locationid from e.g. https://www.instagram.com/explore/locations/212999109/los-angeles-california/)                     | ['cat', 'car', 'dog', 'l:212999109'] |

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | media_min_like       | int | Minimum number of likes on photos to like (set to 0 to disable) | 0    |
 | follow_per_day       | int | Users to follow per day                              | 0    |
 | follow_time          | int | Seconds to wait before unfollowing                   | 5 * 60 * 60 |
+| follow_time_enabled  | bool| Whether to wait seconds set in follow_time before unfollowing | True |
 | unfollow_per_day     | int | Users to unfollow per day                            | 0    |
 | comments_per_day     | int | Comments to post per day                             | 0    |
 | comment_list         | [[str]] | List of word lists for comment generation        | [['this', 'your'], ['photo', 'picture', 'pic', 'shot'], ['is', 'looks', 'is really'], ['great', 'super', 'good'], ['.', '...', '!', '!!']] |

--- a/src/instabot.py
+++ b/src/instabot.py
@@ -180,7 +180,7 @@ class InstaBot:
                  follow_time=5 * 60 * 60, #Cannot be zero
                  follow_time_enabled=True,
                  unfollow_per_day=0,
-                 unfollow_from_recent_feed=True,
+                 unfollow_recent_feed=True,
                  start_at_h=0,
                  start_at_m=0,
                  end_at_h=23,
@@ -230,7 +230,7 @@ class InstaBot:
         self.unfollow_whitelist = unfollow_whitelist
         self.comment_list = comment_list
         self.instaloader = instaloader.Instaloader()
-        self.unfollow_from_recent_feed = unfollow_from_recent_feed
+        self.unfollow_recent_feed = unfollow_recent_feed
 
         self.time_in_day = 24 * 60 * 60
         # Like
@@ -1006,7 +1006,7 @@ class InstaBot:
             if get_username_row_count(self) < 20:
                 self.write_log('    >>>Waiting for database to populate before unfollowing (progress '+str(get_username_row_count(self))+"/20)")                        
                 
-                if self.unfollow_from_recent_feed is True:
+                if self.unfollow_recent_feed is True:
                     self.write_log("Will try to populate using recent feed")
                     self.populate_from_feed()
                 
@@ -1017,7 +1017,7 @@ class InstaBot:
             if self.bot_mode == 0 or self.bot_mode == 3:
 
                 try:
-                    if time.time() > self.next_iteration["Populate"] and self.unfollow_from_recent_feed is True:
+                    if time.time() > self.next_iteration["Populate"] and self.unfollow_recent_feed is True:
                         self.populate_from_feed()
                         self.next_iteration["Populate"] = time.time() + \
                                                     (self.add_time(360))

--- a/src/instabot.py
+++ b/src/instabot.py
@@ -180,6 +180,7 @@ class InstaBot:
                  follow_time=5 * 60 * 60, #Cannot be zero
                  follow_time_enabled=True,
                  unfollow_per_day=0,
+                 unfollow_from_recent_feed=True,
                  start_at_h=0,
                  start_at_m=0,
                  end_at_h=23,
@@ -229,6 +230,7 @@ class InstaBot:
         self.unfollow_whitelist = unfollow_whitelist
         self.comment_list = comment_list
         self.instaloader = instaloader.Instaloader()
+        self.unfollow_from_recent_feed = unfollow_from_recent_feed
 
         self.time_in_day = 24 * 60 * 60
         # Like
@@ -1002,8 +1004,11 @@ class InstaBot:
                 #let bot initialize
                 return 
             if get_username_row_count(self) < 20:
-                self.write_log('    >>>Waiting for database to populate before unfollowing (progress '+str(get_username_row_count(self))+"/20)\n                        (Will try to populate using recent feed)")
-                self.populate_from_feed()
+                self.write_log('    >>>Waiting for database to populate before unfollowing (progress '+str(get_username_row_count(self))+"/20)")                        
+                
+                if self.unfollow_from_recent_feed is True:
+                    self.write_log("Will try to populate using recent feed")
+                    self.populate_from_feed()
                 
                 self.next_iteration["Unfollow"] = time.time() + \
                                                     (self.add_time(self.unfollow_delay)/2)
@@ -1012,7 +1017,7 @@ class InstaBot:
             if self.bot_mode == 0 or self.bot_mode == 3:
 
                 try:
-                    if time.time() > self.next_iteration["Populate"]:
+                    if time.time() > self.next_iteration["Populate"] and self.unfollow_from_recent_feed is True:
                         self.populate_from_feed()
                         self.next_iteration["Populate"] = time.time() + \
                                                     (self.add_time(360))

--- a/src/instabot.py
+++ b/src/instabot.py
@@ -178,6 +178,7 @@ class InstaBot:
                  media_min_like=0,
                  follow_per_day=0,
                  follow_time=5 * 60 * 60, #Cannot be zero
+                 follow_time_enabled=True,
                  unfollow_per_day=0,
                  start_at_h=0,
                  start_at_m=0,
@@ -237,6 +238,7 @@ class InstaBot:
 
         # Follow
         self.follow_time = follow_time #Cannot be zero
+        self.follow_time_enabled = follow_time_enabled
         self.follow_per_day = follow_per_day
         if self.follow_per_day != 0:
             self.follow_delay = self.time_in_day / self.follow_per_day

--- a/src/sql_updates.py
+++ b/src/sql_updates.py
@@ -128,13 +128,15 @@ def get_username_to_unfollow_random(self):
     AND unfollow_count=0 ORDER BY RANDOM() LIMIT 1").fetchone()
     if username:
         return username
-    else:
+    elif self.follow_time_enabled is False:
         username = self.follows_db_c.execute("SELECT * FROM usernames WHERE \
         unfollow_count=0 ORDER BY RANDOM() LIMIT 1").fetchone()
         if username:
             return username
         else:
             return False
+    else:
+        return False
             
             
 def get_username_row_count(self):


### PR DESCRIPTION
Added the following options,

- `unfollow_recent_feed` (bool): If enabled, will populate database with users from recent feed and unfollow if they meet the conditions. Disable if you only want the bot to unfollow people it has previously followed. Default _True_.
- `follow_time_enabled` (bool): Whether to wait seconds set in `follow_time` before unfollowing. Default _True_

`follow_time` was previously not enforced due to a bug, but it should now work if `follow_time_enabled` is _True_.

Changed the README.md and cleared it up a bit.