### PR TITLE
Fix reading boolean flags from config / unfollow fix

### DIFF
--- a/instabot_py/instabot.py
+++ b/instabot_py/instabot.py
@@ -285,12 +285,12 @@ class InstaBot:
         self.instaloader = instaloader.Instaloader()
 
         # Unfollow Criteria & Options
-        self.unfollow_recent_feed = unfollow_recent_feed
-        self.unfollow_not_following = unfollow_not_following
-        self.unfollow_inactive = unfollow_inactive
-        self.unfollow_probably_fake = unfollow_probably_fake
-        self.unfollow_selebgram = unfollow_selebgram
-        self.unfollow_everyone = unfollow_everyone
+        self.unfollow_recent_feed = str(unfollow_recent_feed) == "True"
+        self.unfollow_not_following = str(unfollow_not_following) == "True"
+        self.unfollow_inactive = str(unfollow_inactive) == "True"
+        self.unfollow_probably_fake = str(unfollow_probably_fake) == "True"
+        self.unfollow_selebgram = str(unfollow_selebgram) == "True"
+        self.unfollow_everyone = str(unfollow_everyone) == "True"
 
         self.time_in_day = 24 * 60 * 60
         # Like
@@ -306,7 +306,7 @@ class InstaBot:
 
         # Follow
         self.follow_time = follow_time  # Cannot be zero
-        self.follow_time_enabled = follow_time_enabled
+        self.follow_time_enabled = str(follow_time_enabled) == "True"
         self.follow_per_day = follow_per_day
         if self.follow_per_day != 0:
             self.follow_delay = self.time_in_day / self.follow_per_day


### PR DESCRIPTION
I noticed that flags were not converted to boolean properly. I am not sure I fixed it everywhere, but at least `unfollow_everyone` flag now works.