### PR TITLE
Modify auto_unlike function to process deleted medias

### DIFF
--- a/instabot_py/instabot.py
+++ b/instabot_py/instabot.py
@@ -1141,13 +1141,20 @@ class InstaBot:
             media_to_unlike = self.persistence.get_medias_to_unlike()
             if media_to_unlike:
                 request = self.unlike(media_to_unlike)
+                media_to_unlike_url = f"https://www.{self.get_instagram_url_from_media_id(media_to_unlike)}"
                 if request.status_code == 200:
                     self.persistence.update_media_complete(media_to_unlike)
+                    self.logger.info(f"Unliked media: id: {media_to_unlike}, url: {media_to_unlike_url}")
+                elif request.status_code == 400 and request.text == 'missing media':
+                    self.persistence.update_media_complete(media_to_unlike)
+                    self.logger.info(f"Couldn't unlike media: id: {media_to_unlike}, url: {media_to_unlike_url}. "
+                                     f"It seems this media is no longer exist.")
                 else:
-                    self.logger.critical("Couldn't unlike media, resuming.")
+                    self.logger.critical(f"Couldn't unlike media: id: {media_to_unlike}, url: {media_to_unlike_url}. "
+                                         f"Reason: {request.text}")
                     checking = False
             else:
-                self.logger.debug("no medias to unlike")
+                self.logger.debug("There are no medias left to unlike right now.")
                 checking = False
 
     def auto_unfollow(self):


### PR DESCRIPTION
This PR is inspired by [issue 2178](https://github.com/instabot-py/instabot.py/issues/2178)

1. Added possibility to process deleted from instagram medias. 
If media is deleted, we don't need to unlike it anymore, so we need to update database accordingly. This helps to prevent processing this medias every time we call auto_unlike() function.

2. Added more verbosity information to log output.