### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/instabot_py/__main__.py
+++ b/instabot_py/__main__.py
@@ -252,7 +252,7 @@ def setupinteractive(config, config_location="instabot.config.ini"):
             section = "DEFAULT"
 
         while requiredset is None:
-            if reqset is "req":
+            if reqset == "req":
                 confvar = ask_question(
                     f"Enter value for '{setting}':", tip="This field is required"
                 )


### PR DESCRIPTION
$ python
```
>>> reqset = "re"
>>> reqset += "q"
>>> reqset == "req"
True
>>> reqset is "req"
False
```