### PR TITLE
tox.ini: Run flake8 on Python 3.7 instead of 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ cache_dir = .pytest_cache
 
 [travis]
 python =
-  3.6: py36,flake8
-  3.7: py37,
+  3.6: py36,
+  3.7: py37,flake8
 
 [flake8]
 exclude =


### PR DESCRIPTION
There are syntax changes in 3.7 (like the addition of the keyword async) that are worth testing for.