### PR TITLE
Perform only one unlike action at time

### DIFF
--- a/instabot_py/instabot.py
+++ b/instabot_py/instabot.py
@@ -1168,26 +1168,22 @@ class InstaBot:
             return True
 
     def auto_unlike(self):
-        checking = True
-        while checking:
-            media_to_unlike = self.persistence.get_medias_to_unlike()
-            if media_to_unlike:
-                request = self.unlike(media_to_unlike)
-                media_to_unlike_url = f"https://www.{self.get_instagram_url_from_media_id(media_to_unlike)}"
-                if request.status_code == 200:
-                    self.persistence.update_media_complete(media_to_unlike)
-                    self.logger.info(f"Unliked media: id: {media_to_unlike}, url: {media_to_unlike_url}")
-                elif request.status_code == 400 and request.text == 'missing media':
-                    self.persistence.update_media_complete(media_to_unlike)
-                    self.logger.info(f"Couldn't unlike media: id: {media_to_unlike}, url: {media_to_unlike_url}. "
-                                     f"It seems this media is no longer exist.")
-                else:
-                    self.logger.critical(f"Couldn't unlike media: id: {media_to_unlike}, url: {media_to_unlike_url}. "
-                                         f"Reason: {request.text}")
-                    checking = False
+        media_to_unlike = self.persistence.get_medias_to_unlike()
+        if media_to_unlike:
+            request = self.unlike(media_to_unlike)
+            media_to_unlike_url = f"https://www.{self.get_instagram_url_from_media_id(media_to_unlike)}"
+            if request.status_code == 200:
+                self.persistence.update_media_complete(media_to_unlike)
+                self.logger.info(f"Unliked media: id: {media_to_unlike}, url: {media_to_unlike_url}")
+            elif request.status_code == 400 and request.text == 'missing media':
+                self.persistence.update_media_complete(media_to_unlike)
+                self.logger.info(f"Could not unlike media: id: {media_to_unlike}, url: {media_to_unlike_url}. It seems "
+                                 f"this media is no longer exist.")
             else:
-                self.logger.debug("There are no medias left to unlike right now.")
-                checking = False
+                self.logger.critical(f"Could not unlike media: id: {media_to_unlike}, url: {media_to_unlike_url}. "
+                                     f"Reason: {request.text}")
+        else:
+            self.logger.debug("There are no medias left to unlike right now.")
 
     def auto_unfollow(self):
         checking = True


### PR DESCRIPTION
We need this patch to prevent many unlike calls to Instagram at once. It could be that we stop our bot for some period of time and start it a day later. Bot checks list to unlike from the database and starts to unlike everything from it. Instagram bans our calls after 31-33 attempt. Here it is an example from real life below:
```
2019-06-14 07:38:17,830 - InstaBot - DEBUG - Trying to unlike media
2019-06-14 07:38:18,502 - InstaBot - INFO - Unliked media: id: 2065xxxxxxxxxxxxxxx, url: https://www.instagram.com/p/XXXXXXXXXXX/
........ # about 30 similar requests
2019-06-14 07:38:31,200 - InstaBot - INFO - Unliked media: id: 2064xxxxxxxxxxxxxxx, url: https://www.instagram.com/p/BXXXXXXXXXXX/
2019-06-14 07:38:31,347 - InstaBot - CRITICAL - Couldn't unlike media: id: 2064xxxxxxxxxxxxxxx, url: https://www.instagram.com/p/XXXXXXXXXXX/. Response code: 400, Reason: {"message": "feedback_required", "spam": true, "feedback_title": "You\u2019re Temporarily Blocked", "feedback_message": "It looks like you were misusing this feature by going too fast. You\u2019ve been temporarily blocked from using it. We restrict certain content and actions to protect our community. Tell us if you think we made a mistake.", "feedback_url": "repute/report_problem/instagram_unlike/", "status": "fail"}
```
Also current implementation helps bot to perform number of calls we set in the configuration file.