### PR TITLE
Replaced no longer used write_log call with the right logging call

### DIFF
--- a/instabot_py/instabot.py
+++ b/instabot_py/instabot.py
@@ -949,7 +949,7 @@ class InstaBot:
                                     break
 
                     if keyword_found is False:
-                        self.write_log(
+                        self.logger.debug(
                             f"Won't follow {username}: does not meet keywords requirement. Keywords not found."
                         )
                         return


### PR DESCRIPTION
When one of the keywords provided in the config file is `not found` a log message needs to be printed out. For some reasons, this doesn't happen because of the call of a not available method `write_log` throws an exception.

I've replaced it with the default logging used in the rest of the file :)