### PR TITLE
Fix log output for window_check_every

### DIFF
--- a/instabot_py/instabot.py
+++ b/instabot_py/instabot.py
@@ -747,7 +747,7 @@ class InstaBot:
             datetime.time(self.end_at_h, self.end_at_m), now.time()
         )
         if not ((dns == 0 or dne < dns) and dne != 0):
-            self.logger.info(f"Pause for {self.ban_sleep_time} seconds")
+            self.logger.info(f"Pause for {self.window_check_every} seconds")
             time.sleep(self.window_check_every)
             return False
         else:


### PR DESCRIPTION
Log output was using `ban_sleep_time`, so "Pause for 10800 seconds" was logged, but the interval used was `window_check_every`. So right output would be "Pause for 300 seconds". So I fixed this.