### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "instabot-py --create-config"

--- a/README.md
+++ b/README.md
@@ -141,3 +141,4 @@ logging.loggers.InstaBot.handlers:
 
 - [Telegram Group](https://t.me/joinchat/DYKH-0G_8hsDDoN_iE8ZlA)
 
+[![Run on Repl.it](https://repl.it/badge/github/instabot-py/instabot.py)](https://repl.it/github/instabot-py/instabot.py)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@stijnbamps/instabotpy).